### PR TITLE
feat: switch to using YAML anchors to keep Action versions tidy

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,27 +8,33 @@ on:
       - '.github/workflows/pre-commit.yml'
       - '.pre-commit-config.yaml'
 
+env:
+  actions-checkout-version:     &actions-checkout     actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29      # v4.1.6
+  actions-setup-go-version:     &actions-setup-go     actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7      # v5.0.1
+  actions-setup-python-version: &actions-setup-python actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
+  pre-commit-action-version:    &pre-commit-action    pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd     # v3.0.1
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
+        uses: *actions-checkout
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
+      - uses: *actions-setup-python
         with:
           python-version: 3.11
 
       # needed for pre-commit in nektos/act with https://github.com/scop/pre-commit-shfmt
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7  # v5.0.1
+      - uses: *actions-setup-go
         if: ${{ env.ACT }}
         with:
           go-version: '>=1.22.0'
 
       - name: Lint the repository with pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+        uses: *pre-commit-action
         # watch out for <https://github.com/pre-commit/action/issues/169>
         with:
           extra_args: >


### PR DESCRIPTION
This is just testing if we can use YAML anchors to centrally manage Actions versions.

This makes it seems that may not be the case, but `nektos/act` runs the change in this PR ok locally:
https://github.com/actions/runner/issues/1182